### PR TITLE
 EZP-29308: Disabled overriding Kernel templates

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/EzKernelOverridePass.php
+++ b/src/bundle/DependencyInjection/Compiler/EzKernelOverridePass.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformStandardDesignBundle\DependencyInjection\Compiler;
 
+use EzSystems\EzPlatformStandardDesignBundle\DependencyInjection\EzPlatformStandardDesignExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -27,11 +28,16 @@ class EzKernelOverridePass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $loader = new YamlFileLoader(
-            $container,
-            new FileLocator(__DIR__ . '/../../Resources/config')
+        $overrideTemplates = $container->getParameter(
+            EzPlatformStandardDesignExtension::OVERRIDE_KERNEL_TEMPLATES_PARAM_NAME
         );
-        $loader->load('override/ezpublish.yaml');
+        if ($overrideTemplates) {
+            $loader = new YamlFileLoader(
+                $container,
+                new FileLocator(__DIR__ . '/../../Resources/config')
+            );
+            $loader->load('override/ezpublish.yaml');
+        }
 
         $this->setStandardThemeDirectories($container);
     }

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformStandardDesignBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * Generate Configuration for eZ Platform Standard Design.
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('ez_platform_standard_design');
+
+        $rootNode
+            ->children()
+                ->booleanNode('override_kernel_templates')
+                    ->defaultFalse()
+                    ->info('Enable this to prepend Kernel default template paths with @ezdesign namespace')
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/bundle/DependencyInjection/EzPlatformStandardDesignExtension.php
+++ b/src/bundle/DependencyInjection/EzPlatformStandardDesignExtension.php
@@ -16,6 +16,8 @@ use Symfony\Component\Yaml\Yaml;
 
 class EzPlatformStandardDesignExtension extends Extension implements PrependExtensionInterface
 {
+    const OVERRIDE_KERNEL_TEMPLATES_PARAM_NAME = 'ez_platform_standard_design.override_kernel_templates';
+
     /**
      * Load Bundle Configuration.
      *
@@ -26,7 +28,14 @@ class EzPlatformStandardDesignExtension extends Extension implements PrependExte
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        // Nothing to load so far
+        $configuration = new Configuration();
+
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $container->setParameter(
+            static::OVERRIDE_KERNEL_TEMPLATES_PARAM_NAME,
+            $config['override_kernel_templates']
+        );
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29308](https://jira.ez.no/browse/EZP-29308)
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no, fixes it
| **Tests pass**     | yes
| **Doc needed**     | yes

To ease rising concerns about BC when overriding Kernel template paths configuration settings with `@ezdesign` namespace, this PR adds a Semantic configuration in the form of:
```yaml
ez_platform_standard_design:
    # Enable this to prepend Kernel default template paths with @ezdesign namespace
    override_kernel_templates: false
```

As we've done recently, this would be enabled in meta-repository for new installations, but disabled by default for old ones to avoid unnoticed mapping of existing template which shares the same name as the one from Kernel (CoreBundle).

**TODO**:
- [x] Create semantic configuration
- [x] Load EzPublishCoreBundle overrides only when enabled by the configuration.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
