### PR TITLE
EZP-29724: Fixed Standard Design overwrites of SiteAccess-aware template settings

### DIFF
--- a/src/bundle/Resources/config/override/ezpublish.yaml
+++ b/src/bundle/Resources/config/override/ezpublish.yaml
@@ -8,10 +8,6 @@ parameters:
     ezplatform.default_view_templates.content.embed_image: '@@ezdesign/default/content/embed_image.html.twig'
     ezplatform.default_view_templates.block: '@@ezdesign/default/block/block.html.twig'
 
-    ezsettings.default.pagelayout: '@@ezdesign/pagelayout.html.twig'
-
-    ezsettings.default.field_templates:
-        - { template: '@@ezdesign/content_fields.html.twig', priority: 0 }
-
-    ezsettings.default.fielddefinition_settings_templates:
-        - { template: '@@ezdesign/fielddefinition_settings.html.twig', priority: 0 }
+    ezplatform.default_templates.pagelayout: '@@ezdesign/pagelayout.html.twig'
+    ezplatform.default_templates.field_templates: '@@ezdesign/content_fields.html.twig'
+    ezplatform.default_templates.fielddefinition_settings_templates: '@@ezdesign/fielddefinition_settings.html.twig'

--- a/tests/bundle/DependencyInjection/Compiler/EzKernelOverridePassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/EzKernelOverridePassTest.php
@@ -35,6 +35,8 @@ class EzKernelOverridePassTest extends AbstractCompilerPassTestCase
      */
     protected function registerCompilerPass(ContainerBuilder $container)
     {
+        $container->setParameter('ez_platform_standard_design.override_kernel_templates', true);
+
         $container->addCompilerPass(new EzKernelOverridePass());
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29724](https://jira.ez.no/browse/EZP-29724)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 0.1
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

When used `override_kernel_templates: true` Standard Design force-overrides siteaccess aware configuration making creation of own templates for custom field types very hard.

#### ~Cannot be merged before https://github.com/ezsystems/ezpublish-kernel/pull/2554 is merged (and merged up)~ `Done.`

**TODO**:
- [x] Implement feature / fix a bug.
- [x] ~Implement tests.~
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
