### PR TITLE
EZP-30572: Upgrade `ezsystems/ezplatform-standard-design` to use Symfony 4 components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ cache:
 
 matrix:
     include:
-        - php: 7.1
+        - php: 7.3
           env: PHPUNIT_CONFIG='phpunit.xml'
-        - php: 7.1
+        - php: 7.3
           env: BEHAT_OPTS="--profile=core --suite=web --tags=~@broken --no-interaction" SYMFONY_ENV=behat SYMFONY_DEBUG=1
-        - php: 7.1
+        - php: 7.3
           env: CHECK_CS=true
 
 env:

--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,14 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "symfony/http-kernel": "^3.4",
+        "symfony/http-kernel": "^4.3",
         "ezsystems/ezplatform-design-engine": "^3.0@dev",
-        "ezsystems/ezpublish-kernel": "^8.0"
+        "ezsystems/ezpublish-kernel": "^8.0@dev"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^3.0",
-        "phpunit/phpunit": "^7.1",
-        "friendsofphp/php-cs-fixer": "^2.10"
+        "matthiasnoback/symfony-dependency-injection-test": "^4.0",
+        "phpunit/phpunit": "^8.1",
+        "friendsofphp/php-cs-fixer": "^2.15"
     },
     "autoload": {
         "psr-4": {

--- a/tests/bundle/DependencyInjection/Compiler/EzKernelOverridePassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/EzKernelOverridePassTest.php
@@ -33,7 +33,7 @@ class EzKernelOverridePassTest extends AbstractCompilerPassTestCase
      *
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      */
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->setParameter('ez_platform_standard_design.override_kernel_templates', true);
 

--- a/tests/bundle/DependencyInjection/Compiler/StandardThemePassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/StandardThemePassTest.php
@@ -76,7 +76,7 @@ class StandardThemePassTest extends AbstractCompilerPassTestCase
      *
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      */
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new StandardThemePass());
     }

--- a/tests/bundle/DependencyInjection/EzPlatformStandardDesignExtensionTest.php
+++ b/tests/bundle/DependencyInjection/EzPlatformStandardDesignExtensionTest.php
@@ -13,7 +13,7 @@ use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 
 class EzPlatformStandardDesignExtensionTest extends AbstractExtensionTestCase
 {
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         return [
             new EzPlatformStandardDesignExtension(),


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30572](https://jira.ez.no/browse/EZP-30572)
| **Bug/Improvement**|improvement
| **New feature**    | no
| **Target version** |  `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->

