### PR TITLE
EZP-30846: Dropped deprecated Symfony\Component\Config\Definition\Bui…

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -20,9 +20,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ez_platform_standard_design');
+        $treeBuilder = new TreeBuilder('ez_platform_standard_design');
 
+        $rootNode = $treeBuilder->getRootNode();
         $rootNode
             ->children()
                 ->booleanNode('override_kernel_templates')


### PR DESCRIPTION
…lder\TreeBuilder::root method calls

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30846](https://jira.ez.no/browse/EZP-30846)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Since Symfony 4.3 configuration root name should be passed via constructor instead of using "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method.

More information:
* https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes
* https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#config

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
