### PR TITLE
EZP-31007: Replaced ezpublish-kernel with ezplatform-kernel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "symfony/http-kernel": "^5.0",
         "ezsystems/ezplatform-design-engine": "^3.0@dev",
-        "ezsystems/ezpublish-kernel": "^8.0@dev"
+        "ezsystems/ezplatform-kernel": "^1.0@dev"
     },
     "require-dev": {
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",

--- a/src/bundle/DependencyInjection/Compiler/EzKernelOverridePass.php
+++ b/src/bundle/DependencyInjection/Compiler/EzKernelOverridePass.php
@@ -15,12 +15,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 /**
- * Compiler pass implemented to override ezpublish-kernel default template paths defined in Container.
+ * Compiler pass implemented to override eZ Platform Kernel default template paths defined in Container.
  */
 class EzKernelOverridePass implements CompilerPassInterface
 {
     /**
-     * Load Standard Design configuration which overrides ezpublish-kernel setup.
+     * Load Standard Design configuration which overrides eZ Platform Kernel setup.
      *
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      *


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31007](https://jira.ez.no/browse/EZP-31007)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

This PR replaces `ezpublish-kernel` with `ezplatform-kernel` and fixes dependency issues blocking package installation (due to Composer minimum stability requirements):

- `ezsystems/doctrine-dbal-schema:^1.0@dev` is required  by `ezplatform-kernel:^1.0@dev`.

#### TODO
- [x] Wait for Travis